### PR TITLE
Fix drive mismatch issue

### DIFF
--- a/jellyfin.tf
+++ b/jellyfin.tf
@@ -252,7 +252,7 @@ resource "aws_instance" "jellyfin_server" {
 
   provisioner "remote-exec" {
     inline = [
-      "EBS_DEVICE_NAME=$(lsblk | grep ${var.EBS_MEDIA_VOLUME_SIZE}G | awk '{print $1}')",
+      "EBS_DEVICE_NAME=$(lsblk -b | grep $((1073741824 * ${var.EBS_MEDIA_VOLUME_SIZE})) | awk '{print $1}')",
       "sudo mkfs -t xfs /dev/$${EBS_DEVICE_NAME}",
       "EBS_DEVICE_UUID=$(sudo blkid | grep $${EBS_DEVICE_NAME} | awk -F'\"' '{print $2}')",
       "sudo echo -e \"UUID=$${EBS_DEVICE_UUID} /home/ec2-user/jellyfin/media  xfs  defaults,nofail  0  2\" | sudo tee -a /etc/fstab",


### PR DESCRIPTION
I noticed that for larger drive sizes (over 1 TB), the logic used to identify a drive by its size does not work. This is because `lsblk` uses human-readable drive sizes, so a 1,250 GiB drive, for example is listed as `1.2T` not `1250G` as the existing `grep` command expects.

`.env` file snippet for replicating issue:

```
EBS_MEDIA_VOLUME_SIZE=1250
```

Resulting log when deploying (note errors):

```
terraform-1  | aws_instance.jellyfin_server (remote-exec): Connected!
terraform-1  | aws_instance.jellyfin_server (remote-exec): specified device /dev/ not a file or block device
terraform-1  | aws_instance.jellyfin_server (remote-exec): Usage: mkfs.xfs
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* blocksize */		[-b size=num]
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* metadata */		[-m crc=0|1,finobt=0|1,uuid=xxx,rmapbt=0|1,reflink=0|1,
terraform-1  | aws_instance.jellyfin_server (remote-exec): 			    inobtcount=0|1,bigtime=0|1]
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* data subvol */	[-d agcount=n,agsize=n,file,name=xxx,size=num,
terraform-1  | aws_instance.jellyfin_server (remote-exec): 			    (sunit=value,swidth=value|su=num,sw=num|noalign),
terraform-1  | aws_instance.jellyfin_server (remote-exec): 			    sectsize=num
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* force overwrite */	[-f]
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* inode size */	[-i log=n|perblock=n|size=num,maxpct=n,attr=0|1|2,
terraform-1  | aws_instance.jellyfin_server (remote-exec): 			    projid32bit=0|1,sparse=0|1]
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* no discard */	[-K]
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* log subvol */	[-l agnum=n,internal,size=num,logdev=xxx,version=n
terraform-1  | aws_instance.jellyfin_server (remote-exec): 			    sunit=value|su=num,sectsize=num,lazy-count=0|1]
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* label */		[-L label (maximum 12 characters)]
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* naming */		[-n size=num,version=2|ci,ftype=0|1]
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* no-op info only */	[-N]
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* prototype file */	[-p fname]
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* quiet */		[-q]
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* realtime subvol */	[-r extsize=num,size=num,rtdev=xxx]
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* sectorsize */	[-s size=num]
terraform-1  | aws_instance.jellyfin_server (remote-exec): /* version */		[-V]
terraform-1  | aws_instance.jellyfin_server (remote-exec): 			devicename
terraform-1  | aws_instance.jellyfin_server (remote-exec): <devicename> is required unless -d name=xxx is given.
terraform-1  | aws_instance.jellyfin_server (remote-exec): <num> is xxx (bytes), xxxs (sectors), xxxb (fs blocks), xxxk (xxx KiB),
terraform-1  | aws_instance.jellyfin_server (remote-exec):       xxxm (xxx MiB), xxxg (xxx GiB), xxxt (xxx TiB) or xxxp (xxx PiB).
terraform-1  | aws_instance.jellyfin_server (remote-exec): <value> is xxx (512 byte blocks).
terraform-1  | aws_instance.jellyfin_server (remote-exec): Usage: grep [OPTION]... PATTERN [FILE]...
terraform-1  | aws_instance.jellyfin_server (remote-exec): Try 'grep --help' for more information.
terraform-1  | aws_instance.jellyfin_server (remote-exec): UUID= /home/ec2-user/jellyfin/media  xfs  defaults,nofail  0  2
```